### PR TITLE
Bump winit version to match bevy/main

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ open_url = ["webbrowser"]
 bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["render", "bevy_winit"] }
 egui = "0.12.0"
 webbrowser = { version = "0.5.5", optional = true }
-winit = { version = "0.24.0", features = ["x11"], default-features = false }
+winit = { version = "0.25.0", features = ["x11"], default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 clipboard = { version = "0.5.0", optional = true }


### PR DESCRIPTION
https://github.com/bevyengine/bevy/pull/2186 bumped winit to 0.25 causing dependency mismatch.