### PR TITLE
Fixed lifetimes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,13 @@ version-sync = "0.9.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
+<<<<<<< HEAD
 	"bevy_wgpu",
 	"x11",
 	"png"
+=======
+    "bevy_wgpu",
+    "x11",
+    "png"
+>>>>>>> 4d79b26 (Updated egui to 0.13.0)
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,12 @@ thread_local = { version = "1.1.0", optional = true }
 version-sync = "0.9.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+<<<<<<< HEAD
 bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
 	"bevy_wgpu",
 	"x11",
 	"png"
 ] }
+=======
+bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["bevy_wgpu", "x11", "png"] }
+>>>>>>> 1fac22d (track bevy main branch)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ open_url = ["webbrowser"]
 bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
 	"render",
 	"bevy_winit"
-]}
+] }
 egui = "0.13.0"
 webbrowser = { version = "0.5.5", optional = true }
 winit = { version = "0.25.0", features = ["x11"], default-features = false }
@@ -35,12 +35,8 @@ thread_local = { version = "1.1.0", optional = true }
 version-sync = "0.9.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-<<<<<<< HEAD
 bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
 	"bevy_wgpu",
 	"x11",
 	"png"
 ] }
-=======
-bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = ["bevy_wgpu", "x11", "png"] }
->>>>>>> 1fac22d (track bevy main branch)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,13 +36,7 @@ version-sync = "0.9.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 bevy = { git = "https://github.com/bevyengine/bevy", branch = "main", default-features = false, features = [
-<<<<<<< HEAD
 	"bevy_wgpu",
 	"x11",
 	"png"
-=======
-    "bevy_wgpu",
-    "x11",
-    "png"
->>>>>>> 4d79b26 (Updated egui to 0.13.0)
 ] }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use crate::{EguiContext, EguiInput, EguiOutput, EguiSettings, EguiShapes, WindowSize};
 #[cfg(feature = "open_url")]
 use bevy::log;
@@ -18,29 +20,31 @@ use bevy::{
 };
 
 #[derive(SystemParam)]
-pub struct InputEvents<'a> {
-    ev_cursor_left: EventReader<'a, CursorLeft>,
-    ev_cursor: EventReader<'a, CursorMoved>,
-    ev_mouse_wheel: EventReader<'a, MouseWheel>,
-    ev_received_character: EventReader<'a, ReceivedCharacter>,
-    ev_window_focused: EventReader<'a, WindowFocused>,
-    ev_window_created: EventReader<'a, WindowCreated>,
+pub struct InputEvents<'w, 's> {
+    ev_cursor_left: EventReader<'w, 's, CursorLeft>,
+    ev_cursor: EventReader<'w, 's, CursorMoved>,
+    ev_mouse_wheel: EventReader<'w, 's, MouseWheel>,
+    ev_received_character: EventReader<'w, 's, ReceivedCharacter>,
+    ev_window_focused: EventReader<'w, 's, WindowFocused>,
+    ev_window_created: EventReader<'w, 's, WindowCreated>,
 }
 
 #[derive(SystemParam)]
-pub struct InputResources<'a> {
+pub struct InputResources<'w, 's> {
     #[cfg(feature = "manage_clipboard")]
-    egui_clipboard: Res<'a, crate::EguiClipboard>,
-    mouse_button_input: Res<'a, Input<MouseButton>>,
-    keyboard_input: Res<'a, Input<KeyCode>>,
-    egui_input: ResMut<'a, HashMap<WindowId, EguiInput>>,
+    egui_clipboard: Res<'w, crate::EguiClipboard>,
+    mouse_button_input: Res<'w, Input<MouseButton>>,
+    keyboard_input: Res<'w, Input<KeyCode>>,
+    egui_input: ResMut<'w, HashMap<WindowId, EguiInput>>,
+    #[system_param(ignore)]
+    marker: PhantomData<&'s usize>,
 }
 
 #[derive(SystemParam)]
-pub struct WindowResources<'a> {
-    focused_window: Local<'a, WindowId>,
-    windows: ResMut<'a, Windows>,
-    window_sizes: ResMut<'a, HashMap<WindowId, WindowSize>>,
+pub struct WindowResources<'w, 's> {
+    focused_window: Local<'s, WindowId>,
+    windows: ResMut<'w, Windows>,
+    window_sizes: ResMut<'w, HashMap<WindowId, WindowSize>>,
 }
 
 pub fn process_input(


### PR DESCRIPTION
This PR implements the new lifetimes needed for `#[derive(SystemParam)]` to work.

To be honest, I'm not entirely sure what `'w` and `'s` are meant to represent. However, this seems to have fixed my own Bevy project. I'd appreciate if someone were able to double-check it.